### PR TITLE
fix(drop-frame): event listener is not cleaned up properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netless/combine-player",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:netless-io/netless-combine-player.git",

--- a/src/CombinePlayerImplement.ts
+++ b/src/CombinePlayerImplement.ts
@@ -751,6 +751,7 @@ export class CombinePlayerImplement implements CombinePlayer {
                 this.stateMachine.off([CombinePlayerStatus.ToPause, CombinePlayerStatus.ToPlay]);
                 this.video.off("playing", videoOnPlaying);
                 this.whiteboardEmitter.removeListener("playing", whiteboardOnPlaying);
+                this.whiteboardEmitter.removeListener("pause", whiteboardOnPause);
             },
         );
 


### PR DESCRIPTION
when the whiteboard is in the buffering state and is playing, the event listener is not properly cleaned up, which affects the processing of frame loss logic